### PR TITLE
Join on currency_id to remove duplicate account payables

### DIFF
--- a/models/double_entry_transactions/int_quickbooks__bill_payment_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__bill_payment_double_entry.sql
@@ -27,7 +27,8 @@ ap_accounts as (
 
     select
         account_id,
-        source_relation
+        source_relation,
+        currency_id
     from accounts
 
     where account_type = '{{ var('quickbooks__accounts_payable_reference', 'Accounts Payable') }}'
@@ -53,6 +54,7 @@ bill_payment_join as (
 
     left join ap_accounts
         on ap_accounts.source_relation = bill_payments.source_relation
+        and ap_accounts.currency_id = bill_payments.currency_id
 ),
 
 final as (


### PR DESCRIPTION
Multi-currency means multi-accounts payable.
This PR resolves the currency on accounts payable side. May need to revise accounts receivable side too.