### PR TITLE
Remove duplicate AR accounts for RevenueCat

### DIFF
--- a/models/double_entry_transactions/int_quickbooks__credit_memo_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__credit_memo_double_entry.sql
@@ -39,6 +39,7 @@ df_accounts as (
     where account_type = '{{ var('quickbooks__accounts_receivable_reference', 'Accounts Receivable') }}'
         and is_active
         and not is_sub_account
+        and name != 'Allowance for Doubtful Accounts'
 ),
 
 credit_memo_join as (

--- a/models/double_entry_transactions/int_quickbooks__invoice_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__invoice_double_entry.sql
@@ -91,6 +91,7 @@ ar_accounts as (
     from accounts
 
     where account_type = '{{ var('quickbooks__accounts_receivable_reference', 'Accounts Receivable') }}'
+    and name != 'Allowance for Doubtful Accounts'
 ),
 
 invoice_join as (

--- a/models/double_entry_transactions/int_quickbooks__payment_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__payment_double_entry.sql
@@ -33,6 +33,7 @@ ar_accounts as (
     where account_type = '{{ var('quickbooks__accounts_receivable_reference', 'Accounts Receivable') }}'
         and is_active
         and not is_sub_account
+        and name != 'Allowance for Doubtful Accounts'
 ),
 
 payment_join as (


### PR DESCRIPTION
RevenueCat has duplicate AR accounts, testing a fix to see if this resolves inconsistent amounts before asking them to recategorize accounts.