### PR TITLE
The account id is being incorrectly associated for manual overrides

### DIFF
--- a/models/double_entry_transactions/int_quickbooks__invoice_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__invoice_double_entry.sql
@@ -107,20 +107,20 @@ invoice_join as (
             else invoice_lines.amount
         end as amount,
         case when invoice_lines.detail_type is not null then invoice_lines.detail_type
-            when coalesce(invoice_lines.account_id, items.parent_income_account_id, items.income_account_id, bundle_income_accounts.account_id, invoice_lines.sales_item_account_id) is not null then 'SalesItemLineDetail'
+            when coalesce(invoice_lines.sales_item_account_id, invoice_lines.account_id, items.parent_income_account_id, items.income_account_id, bundle_income_accounts.account_id) is not null then 'SalesItemLineDetail'
             when invoice_lines.discount_account_id is not null then 'DiscountLineDetail'
-            when coalesce(invoice_lines.account_id, items.parent_income_account_id, items.income_account_id, bundle_income_accounts.account_id, invoice_lines.discount_account_id, invoice_lines.sales_item_account_id) is null then 'NoAccountMapping'
+            when coalesce(invoice_lines.sales_item_account_id, invoice_lines.account_id, items.parent_income_account_id, items.income_account_id, bundle_income_accounts.account_id, invoice_lines.discount_account_id) is null then 'NoAccountMapping'
         end as invoice_line_transaction_type,
-        coalesce(invoice_lines.account_id, items.parent_income_account_id, items.income_account_id, bundle_income_accounts.account_id, invoice_lines.discount_account_id, invoice_lines.sales_item_account_id) as account_id,
+        coalesce(invoice_lines.sales_item_account_id, invoice_lines.account_id, items.parent_income_account_id, items.income_account_id, bundle_income_accounts.account_id, invoice_lines.discount_account_id) as account_id,
 
         {% else %}
         invoice_lines.amount as amount,
         case when invoice_lines.detail_type is not null then invoice_lines.detail_type
-            when coalesce(invoice_lines.account_id, items.parent_income_account_id, items.income_account_id, invoice_lines.sales_item_account_id) is not null then 'SalesItemLineDetail'
+            when coalesce(invoice_lines.sales_item_account_id, invoice_lines.account_id, items.parent_income_account_id, items.income_account_id) is not null then 'SalesItemLineDetail'
             when invoice_lines.discount_account_id is not null then 'DiscountLineDetail'
-            when coalesce(invoice_lines.account_id, items.parent_income_account_id, items.income_account_id, invoice_lines.discount_account_id, invoice_lines.sales_item_account_id) is null then 'NoAccountMapping'
+            when coalesce(invoice_lines.sales_item_account_id, invoice_lines.account_id, items.parent_income_account_id, items.income_account_id, invoice_lines.discount_account_id) is null then 'NoAccountMapping'
         end as invoice_line_transaction_type,
-        coalesce(invoice_lines.account_id, items.income_account_id, invoice_lines.discount_account_id, invoice_lines.sales_item_account_id) as account_id,
+        coalesce(invoice_lines.sales_item_account_id, invoice_lines.account_id, items.income_account_id, invoice_lines.discount_account_id) as account_id,
         {% endif %}
 
         coalesce(invoice_lines.sales_item_class_id, invoice_lines.discount_class_id, invoices.class_id) as class_id,


### PR DESCRIPTION
The item account id is incorrectly being picked over the invoice line for manual overrides